### PR TITLE
Use synchronized Chrome settings

### DIFF
--- a/bgscript.js
+++ b/bgscript.js
@@ -9,6 +9,11 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
 
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
 	var url = tab.url;
+
+	if (! /^https?.*$/.test(url)) {
+		return; // ignore non-http(s) schemes (including "chrome://")
+	}
+
 	var host = get_hostname(url);
 
 	with_settings(host, function (settings) {

--- a/bgscript.js
+++ b/bgscript.js
@@ -11,11 +11,11 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
 	var url = tab.url;
 	var host = get_hostname(url);
 
-	with_config(function (config) {
+	with_settings(host, function (settings) {
 		executeScripts(tabId,
 			[
-				{ code: "var css = '"+ addslashes((config[host + '-css'] || '').replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
-				{ code: "var js = '"+ addslashes((config[host + '-js'] || '').replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
+				{ code: "var css = '"+ addslashes((settings.css || '').replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
+				{ code: "var js = '"+ addslashes((settings.js || '').replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
 				{ file: "jquery.js", runAt: 'document_start' },
 				{ file: "styler.js", runAt: 'document_start' }
 			]

--- a/bgscript.js
+++ b/bgscript.js
@@ -10,13 +10,15 @@ chrome.extension.onRequest.addListener(function(request, sender, sendResponse) {
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
 	var url = tab.url;
 	var host = get_hostname(url);
-	executeScripts(tabId, 
-		[
-			{ code: "var css = '"+ addslashes(localStorage[host + '-css'].replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
-			{ code: "var js = '"+ addslashes(localStorage[host + '-js'].replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
-			{ file: "jquery.js", runAt: 'document_start' },
-			{ file: "styler.js", runAt: 'document_start' }
-		]
-	);
 
+	with_config(function (config) {
+		executeScripts(tabId,
+			[
+				{ code: "var css = '"+ addslashes((config[host + '-css'] || '').replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
+				{ code: "var js = '"+ addslashes((config[host + '-js'] || '').replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
+				{ file: "jquery.js", runAt: 'document_start' },
+				{ file: "styler.js", runAt: 'document_start' }
+			]
+		);
+	});
 });

--- a/functions.js
+++ b/functions.js
@@ -27,11 +27,25 @@ function get_hostname(url) {
 }
 
 function with_config(fn) {
-	chrome.storage.sync.get(null, function (config) {
-		fn(config || {});
+	chrome.storage.sync.get('config', function (values) {
+		fn(values.config || {});
 	});
 }
 
 function save_config(config) {
-	chrome.storage.sync.set(config);
+	chrome.storage.sync.set({config: config});
+}
+
+function with_settings(hostname, fn) {
+	chrome.storage.sync.get(hostname, function (values) {
+		fn(values[hostname] || {});
+	});
+}
+
+function save_settings(hostname, settings) {
+	var values = {};
+
+	values[hostname] = settings;
+
+	chrome.storage.sync.set(values);
 }

--- a/functions.js
+++ b/functions.js
@@ -37,8 +37,16 @@ function save_config(config) {
 }
 
 function with_settings(hostname, fn) {
+	function load_legacy_settings() {
+		if (localStorage[hostname + '-js'] || localStorage[hostname + '-css']) {
+			return {
+				js: localStorage[hostname + '-js'],
+				css: localStorage[hostname + '-css']
+			};
+		}
+	}
 	chrome.storage.sync.get(hostname, function (values) {
-		fn(values[hostname] || {});
+		fn(values[hostname] || load_legacy_settings() || {});
 	});
 }
 

--- a/functions.js
+++ b/functions.js
@@ -25,3 +25,13 @@ function cl(data) {
 function get_hostname(url) {
 	return url.toString().replace(/^(.*\/\/[^\/?#]*).*$/,"$1");
 }
+
+function with_config(fn) {
+	chrome.storage.sync.get(null, function (config) {
+		fn(config || {});
+	});
+}
+
+function save_config(config) {
+	chrome.storage.sync.set(config);
+}

--- a/script.js
+++ b/script.js
@@ -21,10 +21,7 @@ $(function() {
 		});
 	}
 	
-	function init_editor(tab, config) {
-		var url = tab.url;
-		var host = get_hostname(url);
-
+	function init_editor(host, config, settings) {
 		var width;
 		var fontsize;
 
@@ -41,21 +38,22 @@ $(function() {
 
 		$('body').prepend('<div class="host">Styler for <a href="' + host + '">' + host + '</a></div>');
 
-		$('.css').val(config[host + '-css']);
-		$('.js').val(config[host + '-js']);
+		$('.css').val(settings.css);
+		$('.js').val(settings.js);
 
 		$(document).on('keyup change', function() {
 			jsCM.save();
 			cssCM.save();
-			config[host + '-css'] = $('.css').val();
-			config[host + '-js'] = $('.js').val();
+			settings.css = $('.css').val();
+			settings.js = $('.js').val();
 			config['width'] = $('.width').val();
 			config['fontsize'] = $('.fontsize').val();
 			save_config(config);
+			save_settings(host, settings);
 			executeScripts(null,
 				[
-					{ code: "var css = '"+ addslashes((config[host + '-css'] || '').replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
-					{ code: "var js = '"+ addslashes((config[host + '-js'] || '').replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
+					{ code: "var css = '"+ addslashes((settings.css || '').replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
+					{ code: "var js = '"+ addslashes((settings.js || '').replace(/(\r\n|\n|\r)/gm,"")) +"';", runAt: 'document_start' },
 					{ file: "jquery.js", runAt: 'document_start' },
 					{ file: "styler.js", runAt: 'document_start' }
 				]
@@ -88,8 +86,13 @@ $(function() {
 	}
 	
 	chrome.tabs.query({'active': true, 'currentWindow': true}, function (tabs) {
+		var url = tabs[0].url;
+		var host = get_hostname(url);
+
 		with_config(function (config) {
-			init_editor(tabs[0], config);
+			with_settings(host, function (settings) {
+				init_editor(host, config, settings);
+			});
 		});
 	});
 


### PR DESCRIPTION
Ported to use chrome.storage API instead of localStorage, as per #1.

Also fixes some `null is not an object` errors in some call sites for `executeScripts()` - this was buggy in the original script, where it was attempting to call `replace()` on the `null`-values initially produced by expressions like `localStorage['js-' + host]`.
