### PR TITLE
Fixed for newest version

### DIFF
--- a/bgscript.js
+++ b/bgscript.js
@@ -19,8 +19,8 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
 	with_settings(host, function (settings) {
 		executeScripts(tabId,
 			[
-				{ code: "var css = atob('"+ btoa(localStorage[host + '-css']) +"');", runAt: 'document_start' },
-				{ code: "var js = atob('"+ btoa(localStorage[host + '-js']) +"');", runAt: 'document_start' },
+				{ code: "var css = "+ JSON.stringify(localStorage[host + '-css']) +";", runAt: 'document_start' },
+				{ code: "var js = "+ JSON.stringify(localStorage[host + '-js']) +";", runAt: 'document_start' },
 				{ file: "jquery.js", runAt: 'document_start' },
 				{ file: "styler.js", runAt: 'document_start' }
 			]

--- a/bgscript.js
+++ b/bgscript.js
@@ -19,8 +19,8 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab){
 	with_settings(host, function (settings) {
 		executeScripts(tabId,
 			[
-				{ code: "var css = "+ JSON.stringify(localStorage[host + '-css']) +";", runAt: 'document_start' },
-				{ code: "var js = "+ JSON.stringify(localStorage[host + '-js']) +";", runAt: 'document_start' },
+				{ code: "var css = "+ JSON.stringify(settings.css || '') +";", runAt: 'document_start' },
+				{ code: "var js = "+ JSON.stringify(settings.js || '') +";", runAt: 'document_start' },
 				{ file: "jquery.js", runAt: 'document_start' },
 				{ file: "styler.js", runAt: 'document_start' }
 			]

--- a/script.js
+++ b/script.js
@@ -52,8 +52,8 @@ $(function() {
 			save_settings(host, settings);
 			executeScripts(null,
 				[
-					{ code: "var css = atob('"+ btoa(localStorage[host + '-css']) +"');", runAt: 'document_start' },
-					{ code: "var js = atob('"+ btoa(localStorage[host + '-js']) +"');", runAt: 'document_start' },
+					{ code: "var css = "+ JSON.stringify(localStorage[host + '-css']) +";", runAt: 'document_start' },
+					{ code: "var js = "+ JSON.stringify(localStorage[host + '-js']) +";", runAt: 'document_start' },
 					{ file: "jquery.js", runAt: 'document_start' },
 					{ file: "styler.js", runAt: 'document_start' }
 				]

--- a/script.js
+++ b/script.js
@@ -52,8 +52,8 @@ $(function() {
 			save_settings(host, settings);
 			executeScripts(null,
 				[
-					{ code: "var css = "+ JSON.stringify(localStorage[host + '-css']) +";", runAt: 'document_start' },
-					{ code: "var js = "+ JSON.stringify(localStorage[host + '-js']) +";", runAt: 'document_start' },
+					{ code: "var css = "+ JSON.stringify(settings.css || '') +";", runAt: 'document_start' },
+					{ code: "var js = "+ JSON.stringify(settings.js || '') +";", runAt: 'document_start' },
 					{ file: "jquery.js", runAt: 'document_start' },
 					{ file: "styler.js", runAt: 'document_start' }
 				]


### PR DESCRIPTION
Seems I missed a commit from mindplay yesterday which was fairly major:

Changed recent ATOB/BTOA to stringify for support past UTF-8

Changed from using localStorage back to using the newest settings.js/css from mindplay's Nov 1 commit.